### PR TITLE
correcting capitalisation of "minc" in DATS.json file

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -39,7 +39,7 @@
 	"distributions": [
  		{
  			"formats": [
- 				"mINC",
+ 				"minc",
  			],
  			"size" : 196,
  			"unit" : {


### PR DESCRIPTION
This PR corrects the capitalisation of "minc" nder distirbutions->formats in the DATS.json file.